### PR TITLE
lcd_st7920: Use a longer delay at the start of each command/data

### DIFF
--- a/config/example-extras.cfg
+++ b/config/example-extras.cfg
@@ -539,10 +539,6 @@
 #sid_pin:
 #   The pins connected to an st7920 type lcd. These parameters must be
 #   provided when using an st7920 display.
-#chip_delay:
-#   This parameter specifies the internal command delay (in seconds)
-#   on st7920 displays. It may be necessary to increase this if the
-#   display shows garbled data. The default is 0.000020.
 
 
 # Custom thermistors (one may define any number of sections with a

--- a/config/generic-re-arm.cfg
+++ b/config/generic-re-arm.cfg
@@ -93,8 +93,3 @@ max_z_accel: 100
 #cs_pin: P0.16
 #sclk_pin: P0.15
 #sid_pin: P0.18
-#chip_delay needs to be set to the below for the LCD to initialise correctly.
-#chip_delay: .000040
-
-
-

--- a/klippy/extras/display.py
+++ b/klippy/extras/display.py
@@ -161,7 +161,9 @@ HD44780_chars = [
 # ST7920 (128x64 graphics) lcd chip
 ######################################################################
 
-ST7920_DELAY = .000020 # Spec says 72us, but faster is possible in practice
+# Spec says 72us, but faster is possible in practice
+ST7920_CMD_DELAY  = .000020
+ST7920_SYNC_DELAY = .000045
 
 class ST7920:
     char_right_arrow = '\x1a'
@@ -182,7 +184,6 @@ class ST7920:
         self.mcu = mcu
         self.oid = self.mcu.create_oid()
         self.mcu.add_config_object(self)
-        self.chip_delay = config.getfloat('chip_delay', ST7920_DELAY, minval=0.)
         self.send_data_cmd = self.send_cmds_cmd = None
         self.is_extended = False
         # framebuffers
@@ -195,9 +196,10 @@ class ST7920:
     def build_config(self):
         self.mcu.add_config_cmd(
             "config_st7920 oid=%u cs_pin=%s sclk_pin=%s sid_pin=%s"
-            " delay_ticks=%d" % (
+            " sync_delay_ticks=%d cmd_delay_ticks=%d" % (
                 self.oid, self.pins[0], self.pins[1], self.pins[2],
-                self.mcu.seconds_to_clock(self.chip_delay)))
+                self.mcu.seconds_to_clock(ST7920_SYNC_DELAY),
+                self.mcu.seconds_to_clock(ST7920_CMD_DELAY)))
         cmd_queue = self.mcu.alloc_command_queue()
         self.send_cmds_cmd = self.mcu.lookup_command(
             "st7920_send_cmds oid=%c cmds=%*s", cq=cmd_queue)


### PR DESCRIPTION
It appears the st7920 requires a longer delay when switching from
command to data mode (and vice-versa).  Slower MCUs don't show a
problem because the klipper command processing time results in a
sufficient delay.  However, some of the faster MCUs can process
klipper commands fast enough that the next st7920 transfer is sent too
fast.  Add an additional delay to account for this.

Signed-off-by: Kevin O'Connor <kevin@koconnor.net>